### PR TITLE
pre-commit: Define hook with a script language

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: lisp-format
   name: formatter of lisp code
   description: Run lisp-format against lisp files
-  language: system
+  language: script
   files: \.(lisp|cl|asd|scm|el)$
   entry: lisp-format -i


### PR DESCRIPTION
Hooks with `script` execute the entry from a path `relative to the root of the hook repository.` meaning lisp-format isn't required to be installed on the system.

Useful for those who use lisp-format just as a pre-commit hook.